### PR TITLE
Updates python-dateutil version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'nydus==0.11.0',
         'redis>=2.7.2',
-        'python-dateutil==1.5',
+        'python-dateutil>=1.5, !=2.0',
     ],
     tests_require=[
         'nose>=1.0',


### PR DESCRIPTION
A few packages demand newer versions of python-dateutil, notably boto3. It would be nice to be able to update this.

According to https://github.com/dateutil/dateutil/blob/master/NEWS only version 2.0 should be backwards incompatible with Python2.